### PR TITLE
fix: reset hide timer based on PanGestureHandler state

### DIFF
--- a/src/Notifier.tsx
+++ b/src/Notifier.tsx
@@ -167,7 +167,7 @@ export class NotifierRoot extends React.PureComponent<ShowNotificationParams, St
   }
 
   private setHideTimer() {
-    const { duration = DEFAULT_DURATION } = this.props;
+    const { duration = DEFAULT_DURATION } = this.showParams ?? {};
     clearTimeout(this.hideTimer);
     if (duration && !isNaN(duration)) {
       this.hideTimer = setTimeout(this.hideNotification, duration);

--- a/src/Notifier.tsx
+++ b/src/Notifier.tsx
@@ -139,15 +139,7 @@ export class NotifierRoot extends React.PureComponent<ShowNotificationParams, St
       return;
     }
 
-    const {
-      duration = DEFAULT_DURATION,
-      title,
-      description,
-      swipeEnabled,
-      Component,
-      componentProps,
-      ...restParams
-    } = params;
+    const { title, description, swipeEnabled, Component, componentProps, ...restParams } = params;
 
     this.setState({
       title,
@@ -160,9 +152,7 @@ export class NotifierRoot extends React.PureComponent<ShowNotificationParams, St
     this.showParams = restParams;
     this.isShown = true;
 
-    if (duration && !isNaN(duration)) {
-      this.hideTimer = setTimeout(this.hideNotification, duration);
-    }
+    this.setHideTimer();
 
     this.translateY.setValue(-DEFAULT_COMPONENT_HEIGHT);
     Animated.timing(this.translateY, {
@@ -174,6 +164,14 @@ export class NotifierRoot extends React.PureComponent<ShowNotificationParams, St
         DEFAULT_ANIMATION_DURATION,
       useNativeDriver: true,
     }).start();
+  }
+
+  private setHideTimer() {
+    const { duration = DEFAULT_DURATION } = this.props;
+    clearTimeout(this.hideTimer);
+    if (duration && !isNaN(duration)) {
+      this.hideTimer = setTimeout(this.hideNotification, duration);
+    }
   }
 
   private onStartHiding() {
@@ -196,9 +194,13 @@ export class NotifierRoot extends React.PureComponent<ShowNotificationParams, St
   }
 
   private onHandlerStateChange({ nativeEvent }: PanGestureHandlerStateChangeEvent) {
+    if (nativeEvent.state === State.ACTIVE) {
+      clearTimeout(this.hideTimer);
+    }
     if (nativeEvent.oldState !== State.ACTIVE) {
       return;
     }
+    this.setHideTimer();
 
     const swipePixelsToClose = -(this.showParams?.swipePixelsToClose ?? SWIPE_PIXELS_TO_CLOSE);
     const isSwipedOut = nativeEvent.translationY < swipePixelsToClose;

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,10 @@ export interface ShowParams {
   /** How fast should be animation after user finished swiping
    * @default 200 */
   swipeAnimationDuration?: number;
+
+  /** Time after notification will disappear. Set to `0` to not hide notification automatically
+   * @default 3000 */
+  duration?: number;
 }
 
 export type QueueMode = 'immediate' | 'next' | 'standby' | 'reset';
@@ -71,10 +75,6 @@ export interface ShowNotificationParams extends ShowParams {
   /** Can notification be hidden by swiping it out
    * @default true */
   swipeEnabled?: boolean;
-
-  /** Time after notification will disappear. Set to `0` to not hide notification automatically
-   * @default 3000 */
-  duration?: number;
 
   /** Component of the notification body. You can use one of the [built-in components](https://github.com/seniv/react-native-notifier#components), or your [custom component](https://github.com/seniv/react-native-notifier#custom-component).
    * @default NotifierComponents.Notification */


### PR DESCRIPTION
### Issue
Notifier keeps showing after hide timer expires

### How to reproduce
- Tap on `Error Alert` from example app
- Hold the notification and swipe slightly to the top (just enough to trigger `onHandlerStateChange`)
- Wait 3 seconds
- Release it
- The notification won't hide anymore

### Test plan
- Do all steps above and it should reset the timer after the notification is released